### PR TITLE
Fix Media Library bulk action redirect to preserve pagination and filters

### DIFF
--- a/src/App/Setup.php
+++ b/src/App/Setup.php
@@ -105,11 +105,25 @@ class Setup
         ];
 
         // Redirect alla pagina della media library con un messaggio di successo
-        $sendback = add_query_arg(
-            $callBackData,
-            admin_url('upload.php')
-        );
-        wp_redirect($sendback);
+        $sendback = wp_get_referer();
+        if (empty($sendback)) {
+            $sendback = admin_url('upload.php');
+        }
+
+        $sendback = remove_query_arg([
+            'action',
+            'action2',
+            'media',
+            '_wpnonce',
+            '_wp_http_referer',
+            'auto_alt_text',
+            'mediaSelected',
+            'mediaUpdated',
+        ], $sendback);
+
+        $sendback = add_query_arg($callBackData, $sendback);
+
+        wp_safe_redirect($sendback);
         exit();
     }
 


### PR DESCRIPTION
**What changed**

- Redirect target now uses the current Media Library URL via `wp_get_referer()` (fallback to `admin_url('upload.php')`).
- Preserves list table state such as `paged`, `search`, and `filters`.
- Strips bulk-action-only query args (`action`, `media`, `_wpnonce`, etc.) before appending plugin notice params.
- Uses `wp_safe_redirect()`.

**Why**

The bulk action previously redirected to `upload.php` without the original query args, causing users to lose their place (e.g. returning to page 1 instead of `&paged=7`).

**Testing notes**

1. Go to **Media > Library**, navigate to a later page (e.g. `paged=7`) and optionally apply a filter/search.
2. Select items, run **Generate Alt Text** bulk action.
3. Verify you return to the same page/filter state and see the admin notice.