### PR TITLE
Configure plugin options via PHP constants in `wp-config.php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,51 @@ In this case, the cause of the error can be seen on the Auto Alt Text -> Error l
 
 We **strongly recommend** defining the new plugin-specific constants in your `wp-config.php`:
 
-`define( 'AAT_ENCRYPTION_KEY',  'a_random_string_of_at_least_64_characters' );`
-`define( 'AAT_ENCRYPTION_SALT', 'another_random_string_of_at_least_64_characters' );`
+`define( 'AATXT_ENCRYPTION_KEY',  'a_random_string_of_at_least_64_characters' );`
+`define( 'AATXT_ENCRYPTION_SALT', 'another_random_string_of_at_least_64_characters' );`
 
 You will find these two define(...) lines already generated for you on the Auto Alt Text » Options page – simply copy & paste them before the `/* That's all, stop editing! Happy publishing. */` line in your `wp-config.php`.
 
 If you choose not to add them, the plugin will continue to work normally, but it will fall back to using your WordPress `LOGGED_IN_KEY` / `LOGGED_IN_SALT`, which may break if those salts are ever changed.
+
+### Configuration via PHP Constants
+
+As an alternative to the admin settings page, any plugin option can be hard-coded directly in `wp-config.php` using PHP constants. This is useful for:
+
+- keeping API keys out of the database entirely
+- locking configuration on managed/multi-environment hosting
+- deploying consistent settings across environments without a database import
+
+When a constant is defined it takes precedence over the database value and the corresponding field in the admin settings page is disabled with a notice indicating which constant controls it.
+
+Add any combination of the following constants to your `wp-config.php` before the `/* That's all, stop editing! */` line:
+
+```php
+// Generation method: 'openai', 'anthropic', 'azure', 'article-title', 'attachment-title', or 'deactivated'
+define( 'AATXT_TYPOLOGY', 'openai' );
+
+// OpenAI
+define( 'AATXT_API_KEY_OPENAI',  'sk-...' );
+define( 'AATXT_MODEL_OPENAI',    'gpt-4o' );   // gpt-4o, gpt-4o-mini, gpt-5, gpt-5-mini, gpt-5-nano
+define( 'AATXT_PROMPT_OPENAI',   'Write a concise alt text for this image.' );
+
+// Anthropic
+define( 'AATXT_API_KEY_ANTHROPIC', 'sk-ant-...' );
+define( 'AATXT_MODEL_ANTHROPIC',   'claude-sonnet-4-20250514' );  // or claude-3-5-haiku-20241022
+define( 'AATXT_PROMPT_ANTHROPIC',  'Write a concise alt text for this image.' );
+
+// Azure Computer Vision
+define( 'AATXT_API_KEY_AZURE_COMPUTER_VISION', '...' );
+define( 'AATXT_ENDPOINT_AZURE_COMPUTER_VISION', 'https://your-instance.cognitiveservices.azure.com/' );
+
+// Azure Translator (optional — only needed if you want a non-English language)
+define( 'AATXT_API_KEY_AZURE_TRANSLATE_INSTANCE', '...' );
+define( 'AATXT_ENDPOINT_AZURE_TRANSLATE_INSTANCE', 'https://api.cognitive.microsofttranslator.com/' );
+define( 'AATXT_REGION_AZURE_TRANSLATE_INSTANCE', 'westeurope' );
+define( 'AATXT_LANGUAGE_AZURE_TRANSLATE_INSTANCE', 'en' );
+
+// Behaviour
+define( 'AATXT_PRESERVE_EXISTING_ALT_TEXT', '1' );  // '1' = keep existing alt text, '0' = overwrite
+```
+
+**Note:** API key constants are plain text — do not encrypt them. The plugin reads them directly and skips the decryption step that applies to database-stored keys.

--- a/readme.txt
+++ b/readme.txt
@@ -137,12 +137,52 @@ For accurate information on privacy and conditions of use, please directly consu
 
 We **strongly recommend** defining the new plugin-specific constants in your `wp-config.php`:
 
-`define( 'AAT_ENCRYPTION_KEY',  'a_random_string_of_at_least_64_characters' );`
-`define( 'AAT_ENCRYPTION_SALT', 'another_random_string_of_at_least_64_characters' );`
+`define( 'AATXT_ENCRYPTION_KEY',  'a_random_string_of_at_least_64_characters' );`
+`define( 'AATXT_ENCRYPTION_SALT', 'another_random_string_of_at_least_64_characters' );`
 
 You will find these two define(...) lines already generated for you on the Auto Alt Text » Options page – simply copy & paste them before the `/* That's all, stop editing! Happy publishing. */` line in your `wp-config.php`.
 
 If you choose not to add them, the plugin will continue to work normally, but it will fall back to using your WordPress `LOGGED_IN_KEY` / `LOGGED_IN_SALT`, which may break if those salts are ever changed.
+
+## Configuration via PHP Constants
+
+Any plugin option can be hard-coded in `wp-config.php` using PHP constants instead of (or in place of) the admin settings page. This is useful for keeping API keys out of the database, locking configuration on managed hosting, or maintaining consistent settings across environments.
+
+When a constant is defined it takes precedence over the database value and the corresponding field on the settings page is disabled with a notice indicating which constant controls it.
+
+Add any combination of the following to your `wp-config.php` before the `/* That's all, stop editing! */` line:
+
+`define( 'AATXT_TYPOLOGY', 'openai' );` — generation method: openai, anthropic, azure, article-title, attachment-title, or deactivated
+
+**OpenAI**
+
+`define( 'AATXT_API_KEY_OPENAI', 'sk-...' );`
+`define( 'AATXT_MODEL_OPENAI', 'gpt-4o' );` — gpt-4o, gpt-4o-mini, gpt-5, gpt-5-mini, gpt-5-nano
+`define( 'AATXT_PROMPT_OPENAI', 'Write a concise alt text for this image.' );`
+
+**Anthropic**
+
+`define( 'AATXT_API_KEY_ANTHROPIC', 'sk-ant-...' );`
+`define( 'AATXT_MODEL_ANTHROPIC', 'claude-sonnet-4-20250514' );` — or claude-3-5-haiku-20241022
+`define( 'AATXT_PROMPT_ANTHROPIC', 'Write a concise alt text for this image.' );`
+
+**Azure Computer Vision**
+
+`define( 'AATXT_API_KEY_AZURE_COMPUTER_VISION', '...' );`
+`define( 'AATXT_ENDPOINT_AZURE_COMPUTER_VISION', 'https://your-instance.cognitiveservices.azure.com/' );`
+
+**Azure Translator (optional — only needed for non-English output)**
+
+`define( 'AATXT_API_KEY_AZURE_TRANSLATE_INSTANCE', '...' );`
+`define( 'AATXT_ENDPOINT_AZURE_TRANSLATE_INSTANCE', 'https://api.cognitive.microsofttranslator.com/' );`
+`define( 'AATXT_REGION_AZURE_TRANSLATE_INSTANCE', 'westeurope' );`
+`define( 'AATXT_LANGUAGE_AZURE_TRANSLATE_INSTANCE', 'en' );`
+
+**Behaviour**
+
+`define( 'AATXT_PRESERVE_EXISTING_ALT_TEXT', '1' );` — '1' to keep existing alt text, '0' to overwrite
+
+Note: API key constants are plain text — do not encrypt them. The plugin reads them directly and skips the decryption step that applies to database-stored keys.
 
 ## Disclaimer
 Auto Alt Text is a plugin that helps users automatically generate Alt Texts of their images using AI services such as OpenAI's ChatGPT or Microsoft Azure.
@@ -167,15 +207,15 @@ This message appears because the plugin was unable to decrypt your stored API Ke
 
 **Common causes**
 - You (or another plugin) have changed the WordPress authentication salts (`LOGGED_IN_KEY` / `LOGGED_IN_SALT`) in your `wp-config.php` after saving the API Key.
-- You haven’t defined the recommended plugin-specific constants (`AAT_ENCRYPTION_KEY` / `AAT_ENCRYPTION_SALT`) in your `wp-config.php`, so the plugin fell back to the WordPress salts.
+- You haven’t defined the recommended plugin-specific constants (`AATXT_ENCRYPTION_KEY` / `AATXT_ENCRYPTION_SALT`) in your `wp-config.php`, so the plugin fell back to the WordPress salts.
 
 **How to fix**
 1. Go to **Auto Alt Text » Options** in your WordPress admin.
 2. Re-enter your API Key in the appropriate field and click **Save Changes**.
 3. _(Recommended)_ Prevent this issue in the future by adding these lines **before** the `/* That's all, stop editing! Happy publishing. */` comment in your `wp-config.php`:
    ```
-   define( 'AAT_ENCRYPTION_KEY',  'a_random_string_of_at_least_64_characters' );
-   define( 'AAT_ENCRYPTION_SALT', 'another_random_string_of_at_least_64_characters' );
+   define( 'AATXT_ENCRYPTION_KEY',  'a_random_string_of_at_least_64_characters' );
+   define( 'AATXT_ENCRYPTION_SALT', 'another_random_string_of_at_least_64_characters' );
    ```
 
 This ensures the plugin uses stable, plugin-specific values for encryption and won’t break if WordPress salts are ever changed again.

--- a/src/App/Admin/PluginOptions.php
+++ b/src/App/Admin/PluginOptions.php
@@ -8,6 +8,7 @@ use AATXT\App\Configuration\AzureConfig;
 use AATXT\App\Core\Container;
 use AATXT\App\Exceptions\Azure\AzureTranslateInstanceException;
 use AATXT\App\Infrastructure\Http\WordPressHttpClient;
+use AATXT\App\Infrastructure\Repositories\ConstantsResolver;
 use AATXT\App\Utilities\AssetsManager;
 use AATXT\App\Utilities\Encryption;
 use AATXT\Config\Constants;
@@ -279,8 +280,10 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
 
                 ?>
 
+                <?php $typologyLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_TYPOLOGY); ?>
                 <select name="<?php echo esc_attr(Constants::AATXT_OPTION_FIELD_TYPOLOGY); ?>"
-                        id="<?php echo esc_attr(Constants::AATXT_OPTION_FIELD_TYPOLOGY); ?>">
+                        id="<?php echo esc_attr(Constants::AATXT_OPTION_FIELD_TYPOLOGY); ?>"
+                        <?php echo $typologyLocked ? 'disabled="disabled"' : ''; ?>>
                     <option value="<?php echo esc_attr(Constants::AATXT_OPTION_TYPOLOGY_DEACTIVATED); ?>"<?php echo esc_attr(self::selected($typology, Constants::AATXT_OPTION_TYPOLOGY_DEACTIVATED)); ?>><?php esc_html_e("Deactivated", 'auto-alt-text'); ?></option>
                     <option value="<?php echo esc_attr(Constants::AATXT_OPTION_TYPOLOGY_CHOICE_OPENAI); ?>"<?php echo esc_attr(self::selected($typology, Constants::AATXT_OPTION_TYPOLOGY_CHOICE_OPENAI)); ?>><?php esc_html_e("OpenAI's APIs", 'auto-alt-text'); ?></option>
                     <option value="<?php echo esc_attr(Constants::AATXT_OPTION_TYPOLOGY_CHOICE_ANTHROPIC); ?>"<?php echo esc_attr(self::selected($typology, Constants::AATXT_OPTION_TYPOLOGY_CHOICE_ANTHROPIC)); ?>><?php esc_html_e("Antrhopic's APIs", 'auto-alt-text'); ?></option>
@@ -289,6 +292,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
                     <option value="<?php echo esc_attr(Constants::AATXT_OPTION_TYPOLOGY_CHOICE_ATTACHMENT_TITLE); ?>"<?php echo esc_attr(self::selected($typology, Constants::AATXT_OPTION_TYPOLOGY_CHOICE_ATTACHMENT_TITLE)); ?>><?php esc_html_e("Title of the attachment (not AI)", 'auto-alt-text'); ?></option>
                 </select>
                 <?php
+                if ($typologyLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_TYPOLOGY); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
                 echo '<div class="plugin-option type-article-title"><strong>' . esc_html__('Notice', 'auto-alt-text') . '</strong>: ' .
@@ -298,14 +304,18 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
 
                 $openaiModel = self::openAiModel();
 
+                $openaiModelLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI);
                 echo '<div class="plugin-option type-openai">';
                 echo '<label for="' .  esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) . '">' . esc_html__('Model', 'auto-alt-text') . '</label>';
 
-                echo '<select name="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) . '" id="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) . '">';
+                echo '<select name="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) . '" id="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) . '"' . ($openaiModelLocked ? ' disabled="disabled"' : '') . '>';
                 foreach(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI_OPTIONS as $key => $value) {
                     echo '<option value="' . esc_attr($key) . '" ' . esc_attr(self::selected($openaiModel, $key)) . '>' . esc_html($value) . '</option>';
                 }
                 echo '</select>';
+                if ($openaiModelLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
                 echo '<div class="plugin-option type-openai"><strong>' . esc_html__('Notice', 'auto-alt-text') . '</strong>: ' .
@@ -314,35 +324,58 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
                     esc_html__('In case of errors, it is still possible to find the specific reason stated on the', 'auto-alt-text') . ' <a href="' . esc_url(menu_page_url(Constants::AATXT_PLUGIN_OPTION_LOG_PAGE_SLUG, false)) . '">' . esc_html__('error log page', 'auto-alt-text') . '</a>.' .
                     '</div>';
 
+                $openaiKeyLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI);
                 echo '<div class="plugin-option type-openai">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI) . '">' . esc_html__('OpenAI API Key', 'auto-alt-text') . '</label>';
-                echo '<p class="description">' . esc_html__("Enter your API Key", 'auto-alt-text') . '</p>';
-                $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI);
-                echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI) . '" value="' . esc_attr((Encryption::make())->decrypt($apiKey)) . '" />';
+                if (! $openaiKeyLocked) {
+                    echo '<p class="description">' . esc_html__("Enter your API Key", 'auto-alt-text') . '</p>';
+                    $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI);
+                    echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI) . '" value="' . esc_attr((Encryption::make())->decrypt($apiKey)) . '" />';
+                } else {
+                    echo '<input type="password" value="••••••••" disabled="disabled" />';
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
+                $openaiPromptLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI);
                 echo '<div class="plugin-option type-openai">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI) . '">' . esc_html__('Prompt', 'auto-alt-text') . '</label>';
                 echo '<p class="description">' . esc_html__("Enter a specific and detailed prompt according to your needs.", 'auto-alt-text') . '</p>';
                 $defaultPrompt = sprintf(esc_html__("Act like an SEO expert and write an alt text of up to 125 characters for this image.", 'auto-alt-text'), Constants::AATXT_IMAGE_URL_TAG);
                 $prompt = get_option(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI) ?: $defaultPrompt;
-                echo '<textarea name="' . esc_attr(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI) . '" rows="5" cols="50">' . esc_textarea($prompt) . '</textarea>';
+                if ($openaiPromptLocked) {
+                    $prompt = self::openAiPrompt() ?: $defaultPrompt;
+                }
+                echo '<textarea name="' . esc_attr(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI) . '" rows="5" cols="50"' . ($openaiPromptLocked ? ' disabled="disabled"' : '') . '>' . esc_textarea($prompt) . '</textarea>';
+                if ($openaiPromptLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
                 echo '<div class="plugin-option type-azure">' . esc_html__("Fill out the following fields to leverage Azure's computer vision services to generate the Alt texts.", 'auto-alt-text') . '</div>';
 
+                $azureCvKeyLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION);
                 echo '<div class="plugin-option type-azure">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION) . '">' . esc_html__('Azure Computer Vision API Key', 'auto-alt-text') . '</label>';
-                echo '<p class="description">' . esc_html__("Enter the API key for the Computer Vision service of your Azure account.", 'auto-alt-text') . '</p>';
-                $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION);
-                echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION) . '" value="' . esc_attr((Encryption::make())->decrypt($apiKey)) . '" />';
+                if (! $azureCvKeyLocked) {
+                    echo '<p class="description">' . esc_html__("Enter the API key for the Computer Vision service of your Azure account.", 'auto-alt-text') . '</p>';
+                    $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION);
+                    echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION) . '" value="' . esc_attr((Encryption::make())->decrypt($apiKey)) . '" />';
+                } else {
+                    echo '<input type="password" value="••••••••" disabled="disabled" />';
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
+                $azureCvEndpointLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION);
                 echo '<div class="plugin-option type-azure">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION) . '">' . esc_html__('Azure Computer Vision Endpoint', 'auto-alt-text') . '</label>';
                 echo '<p class="description">' . esc_html__("Enter the endpoint of the Computer Vision service.", 'auto-alt-text') . ' (es. https://computer-vision-france-central.cognitiveservices.azure.com/)</p>';
-                $endpoint = get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION);
-                echo '<input type="text" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION) . '" value="' . esc_attr($endpoint) . '" />';
+                $endpoint = $azureCvEndpointLocked ? self::endpointAzureComputerVision() : get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION);
+                echo '<input type="text" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION) . '" value="' . esc_attr($endpoint) . '"' . ($azureCvEndpointLocked ? ' disabled="disabled"' : '') . ' />';
+                if ($azureCvEndpointLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
                 echo '<div class="plugin-option type-azure">' .
@@ -351,32 +384,51 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
                     esc_html__('After saving the changes you can select the desired language.', 'auto-alt-text') .
                     '</div>';
 
+                $azureTranslateKeyLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE);
                 echo '<div class="plugin-option type-azure">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE) . '">' . esc_html__('Azure Translate Instance API Key', 'auto-alt-text') . '</label>';
-                echo '<p class="description">' . esc_html__("Enter your API key for the Azure Translate Instance service.", 'auto-alt-text') . '</p>';
-                $translationApiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE);
-                echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE) . '" value="' . esc_attr((Encryption::make())->decrypt($translationApiKey)) . '" class="notRequired" />';
+                if (! $azureTranslateKeyLocked) {
+                    echo '<p class="description">' . esc_html__("Enter your API key for the Azure Translate Instance service.", 'auto-alt-text') . '</p>';
+                    $translationApiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE);
+                    echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE) . '" value="' . esc_attr((Encryption::make())->decrypt($translationApiKey)) . '" class="notRequired" />';
+                } else {
+                    $translationApiKey = self::apiKeyAzureTranslateInstance();
+                    echo '<input type="password" value="••••••••" disabled="disabled" class="notRequired" />';
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
+                $azureTranslateEndpointLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE);
                 echo '<div class="plugin-option type-azure">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE) . '">' . esc_html__('Azure Translate Instance Endpoint', 'auto-alt-text') . '</label>';
                 echo '<p class="description">' . esc_html__("Enter the endpoint of the Translate Instance service", 'auto-alt-text') . ' (es. https://api.cognitive.microsofttranslator.com/)</p>';
-                $translationEndpoint = get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE);
-                echo '<input type="text" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE) . '" value="' . esc_attr($translationEndpoint) . '" class="notRequired" />';
+                $translationEndpoint = $azureTranslateEndpointLocked ? self::endpointAzureTranslateInstance() : get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE);
+                echo '<input type="text" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE) . '" value="' . esc_attr($translationEndpoint) . '" class="notRequired"' . ($azureTranslateEndpointLocked ? ' disabled="disabled"' : '') . ' />';
+                if ($azureTranslateEndpointLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
+                $azureTranslateRegionLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE);
                 echo '<div class="plugin-option type-azure">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE) . '">' . esc_html__('Azure Translate Instance Region', 'auto-alt-text') . '</label>';
                 echo '<p class="description">' . esc_html__("Enter the region of the Azure Translate Instance service.", 'auto-alt-text') . ' (es. westeurope)</p>';
-                $translationRegion = get_option(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE);
-                echo '<input type="text" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE) . '" value="' . esc_attr($translationRegion) . '" class="notRequired" />';
+                $translationRegion = $azureTranslateRegionLocked ? self::regionAzureTranslateInstance() : get_option(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE);
+                echo '<input type="text" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE) . '" value="' . esc_attr($translationRegion) . '" class="notRequired"' . ($azureTranslateRegionLocked ? ' disabled="disabled"' : '') . ' />';
+                if ($azureTranslateRegionLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
-                if ($translationApiKey && $translationEndpoint && $translationRegion):
+                $resolvedTranslationApiKey  = $azureTranslateKeyLocked ? self::apiKeyAzureTranslateInstance() : (isset($translationApiKey) ? $translationApiKey : get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE));
+                $resolvedTranslationEndpoint = $azureTranslateEndpointLocked ? $translationEndpoint : get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE);
+                $resolvedTranslationRegion   = $azureTranslateRegionLocked ? $translationRegion : get_option(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE);
+                if ($resolvedTranslationApiKey && $resolvedTranslationEndpoint && $resolvedTranslationRegion):
+                    $languageLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE);
                     echo '<div class="plugin-option type-azure">';
                     echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE) . '">' . esc_html__('Alt Text Language', 'auto-alt-text') . '</label>';
                     echo '<p class="description">' . esc_html__("Select the language in which the alt text should be written.", 'auto-alt-text') . '</p>';
-                    $currentLanguage = get_option(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE);
+                    $currentLanguage = self::languageAzureTranslateInstance();
 
                     try {
                         $httpClient = new WordPressHttpClient();
@@ -405,7 +457,8 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
 
                     ?>
                     <select name="<?php echo esc_attr(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE); ?>"
-                            id="<?php echo esc_attr(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE); ?>">
+                            id="<?php echo esc_attr(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE); ?>"
+                            <?php echo $languageLocked ? 'disabled="disabled"' : ''; ?>>
                         <?php
                         foreach ($supportedLanguages as $key => $language):
                             ?>
@@ -414,44 +467,64 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
                         endforeach;
                         ?>
                     </select>
-
                     <?php
+                    if ($languageLocked) {
+                        echo self::constantNotice(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    }
 
                     echo '</div>';
                 endif;
 
+                $anthropicKeyLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC);
                 echo '<div class="plugin-option type-anthropic">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC) . '">' . esc_html__('Antrhopic API Key', 'auto-alt-text') . '</label>';
-                echo '<p class="description">' . esc_html__("Enter your API Key", 'auto-alt-text') . '</p>';
-                $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC);
-                echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC) . '" value="' . esc_attr((Encryption::make())->decrypt($apiKey)) . '" />';
+                if (! $anthropicKeyLocked) {
+                    echo '<p class="description">' . esc_html__("Enter your API Key", 'auto-alt-text') . '</p>';
+                    $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC);
+                    echo '<input type="password" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC) . '" value="' . esc_attr((Encryption::make())->decrypt($apiKey)) . '" />';
+                } else {
+                    echo '<input type="password" value="••••••••" disabled="disabled" />';
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
                 $anthropicModel = self::anthropicModel();
 
+                $anthropicModelLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC);
                 echo '<div class="plugin-option type-anthropic">';
                 echo '<label for="' .  esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) . '">' . esc_html__('Model', 'auto-alt-text') . '</label>';
 
-                echo '<select name="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) . '" id="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) . '">';
+                echo '<select name="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) . '" id="' . esc_attr(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) . '"' . ($anthropicModelLocked ? ' disabled="disabled"' : '') . '>';
                 foreach(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC_OPTIONS as $key => $value) {
                     echo '<option value="' . esc_attr($key) . '" ' . esc_attr(self::selected($anthropicModel, $key)) . '>' . esc_html($value) . '</option>';
                 }
                 echo '</select>';
+                if ($anthropicModelLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
+                $anthropicPromptLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC);
                 echo '<div class="plugin-option type-anthropic">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC) . '">' . esc_html__('Prompt', 'auto-alt-text') . '</label>';
                 echo '<p class="description">' . esc_html__("Enter a specific and detailed prompt according to your needs.", 'auto-alt-text') . '</p>';
                 $defaultPrompt = sprintf(esc_html__("Act like an SEO expert and write an alt text of up to 125 characters for this image. Return only the complete alt text.", 'auto-alt-text'), Constants::AATXT_IMAGE_URL_TAG);
-                $prompt = get_option(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC) ?: $defaultPrompt;
-                echo '<textarea name="' . esc_attr(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC) . '" rows="5" cols="50">' . esc_textarea($prompt) . '</textarea>';
+                $anthropicPromptValue = $anthropicPromptLocked ? (self::anthropicPrompt() ?: $defaultPrompt) : (get_option(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC) ?: $defaultPrompt);
+                echo '<textarea name="' . esc_attr(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC) . '" rows="5" cols="50"' . ($anthropicPromptLocked ? ' disabled="disabled"' : '') . '>' . esc_textarea($anthropicPromptValue) . '</textarea>';
+                if ($anthropicPromptLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
+                $preserveLocked = self::lockedByConstant(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT);
                 echo '<div class="plugin-option type-article-title type-attachment-title type-openai type-azure type-anthropic">';
                 echo '<label for="' . esc_attr(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT) . '">' . esc_html__('Keep existing alt text', 'auto-alt-text') . '</label>';
                 echo '<p class="description">' . esc_html__("If checked, the existing alt text of images will not be overwritten.", 'auto-alt-text') . '</p>';
-                $preserveAltText = get_option(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT);
-                echo '<input type="checkbox" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT) . '" value="1" class="notRequired" ' . checked(1, $preserveAltText, false) . ' />';
+                $preserveAltText = $preserveLocked ? self::preserveExistingAltText() : get_option(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT);
+                echo '<input type="checkbox" name="' . esc_attr(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT) . '" value="1" class="notRequired" ' . checked(1, $preserveAltText, false) . ($preserveLocked ? ' disabled="disabled"' : '') . ' />';
+                if ($preserveLocked) {
+                    echo self::constantNotice(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
                 echo '</div>';
 
                 submit_button();
@@ -503,16 +576,25 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function typology(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_TYPOLOGY)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_TYPOLOGY) ?? '';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_TYPOLOGY);
     }
 
     public static function openAiModel(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) ?? Constants::AATXT_GPT4O;
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_MODEL_OPENAI) ?: Constants::AATXT_GPT4O;
     }
 
     public static function anthropicModel(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) ?? Constants::AATXT_CLAUDE_HAIKU_3_5;
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_MODEL_ANTHROPIC) ?: Constants::AATXT_CLAUDE_HAIKU_3_5;
     }
 
@@ -521,6 +603,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function openAiPrompt(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI) ?? '';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_PROMPT_OPENAI);
     }
 
@@ -529,6 +614,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function anthropicPrompt(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC) ?? '';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_PROMPT_ANTHROPIC);
     }
 
@@ -537,6 +625,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function apiKeyOpenAI(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI) ?? '';
+        }
         $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI);
         return (Encryption::make())->decrypt($apiKey);
     }
@@ -546,6 +637,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function apiKeyAnthropic(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC) ?? '';
+        }
         $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC);
         return (Encryption::make())->decrypt($apiKey);
     }
@@ -555,6 +649,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function apiKeyAzureComputerVision(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION) ?? '';
+        }
         $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION);
         return (Encryption::make())->decrypt($apiKey);
     }
@@ -564,6 +661,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function endpointAzureComputerVision(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION) ?? '';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_COMPUTER_VISION);
     }
 
@@ -572,6 +672,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function apiKeyAzureTranslateInstance(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE) ?? '';
+        }
         $apiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE);
         return (Encryption::make())->decrypt($apiKey);
     }
@@ -581,6 +684,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function endpointAzureTranslateInstance(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE) ?? '';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_ENDPOINT_AZURE_TRANSLATE_INSTANCE);
     }
 
@@ -589,6 +695,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function regionAzureTranslateInstance(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE) ?? '';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_REGION_AZURE_TRANSLATE_INSTANCE);
     }
 
@@ -597,6 +706,9 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function languageAzureTranslateInstance(): string
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE)) {
+            return ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE) ?? 'en';
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_LANGUAGE_AZURE_TRANSLATE_INSTANCE) ?: 'en';
     }
 
@@ -605,7 +717,34 @@ define('AATXT_ENCRYPTION_SALT', '<?php echo esc_html( $suggestedSalt ); ?>');
      */
     public static function preserveExistingAltText(): bool
     {
+        if (ConstantsResolver::has(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT)) {
+            return (bool) ConstantsResolver::get(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT);
+        }
         return get_option(Constants::AATXT_OPTION_FIELD_PRESERVE_EXISTING_ALT_TEXT);
+    }
+
+    /**
+     * Whether a field is locked by a PHP constant.
+     */
+    private static function lockedByConstant(string $optionKey): bool
+    {
+        return ConstantsResolver::has($optionKey);
+    }
+
+    /**
+     * Render the "locked by constant" notice for a field.
+     */
+    private static function constantNotice(string $optionKey): string
+    {
+        $name = ConstantsResolver::getConstantName($optionKey);
+        return '<p class="description" style="color:#b26900; margin-top:4px;">'
+            . '<span class="dashicons dashicons-lock" style="font-size:14px; vertical-align:middle;"></span> '
+            . sprintf(
+                /* translators: %s: PHP constant name */
+                esc_html__('Set via PHP constant %s — edit in wp-config.php to change.', 'auto-alt-text'),
+                '<code>' . esc_html($name) . '</code>'
+            )
+            . '</p>';
     }
 
     public static function sanitizeUrl($input): string

--- a/src/App/Admin/PluginOptions.php
+++ b/src/App/Admin/PluginOptions.php
@@ -106,6 +106,15 @@ class PluginOptions
             return;
         }
 
+        $hasStoredApiKey = get_option(Constants::AATXT_OPTION_FIELD_API_KEY_OPENAI)
+            || get_option(Constants::AATXT_OPTION_FIELD_API_KEY_ANTHROPIC)
+            || get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_COMPUTER_VISION)
+            || get_option(Constants::AATXT_OPTION_FIELD_API_KEY_AZURE_TRANSLATE_INSTANCE);
+
+        if ( ! $hasStoredApiKey ) {
+            return;
+        }
+
         $suggestedKey  = bin2hex(random_bytes(32));
         $suggestedSalt = bin2hex(random_bytes(32));
         ?>

--- a/src/App/Infrastructure/Repositories/ConstantsResolver.php
+++ b/src/App/Infrastructure/Repositories/ConstantsResolver.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AATXT\App\Infrastructure\Repositories;
+
+/**
+ * Resolves plugin configuration from PHP constants defined in wp-config.php.
+ *
+ * Maps option keys to their PHP constant equivalents, allowing site owners
+ * to hard-code configuration values at the infrastructure level rather than
+ * storing them in the database. Constants take precedence over database values
+ * when defined.
+ *
+ * Example wp-config.php usage:
+ *   define('AATXT_API_KEY_OPENAI', 'sk-...');
+ *   define('AATXT_TYPOLOGY', 'openai');
+ */
+final class ConstantsResolver
+{
+    /**
+     * Map of WordPress option key => PHP constant name.
+     *
+     * @var array<string, string>
+     */
+    private const OPTION_CONSTANT_MAP = [
+        'aatxt_typology'                           => 'AATXT_TYPOLOGY',
+        'aatxt_api_key_openai'                     => 'AATXT_API_KEY_OPENAI',
+        'aatxt_model_openai'                       => 'AATXT_MODEL_OPENAI',
+        'aatxt_prompt_openai'                      => 'AATXT_PROMPT_OPENAI',
+        'aatxt_api_key_anthropic'                  => 'AATXT_API_KEY_ANTHROPIC',
+        'aatxt_model_anthropic'                    => 'AATXT_MODEL_ANTHROPIC',
+        'aatxt_prompt_anthropic'                   => 'AATXT_PROMPT_ANTHROPIC',
+        'aatxt_api_key_azure_computer_vision'      => 'AATXT_API_KEY_AZURE_COMPUTER_VISION',
+        'aatxt_endpoint-azure-computer-vision'     => 'AATXT_ENDPOINT_AZURE_COMPUTER_VISION',
+        'aatxt_api_key_azure_translate_instance'   => 'AATXT_API_KEY_AZURE_TRANSLATE_INSTANCE',
+        'aatxt_endpoint-azure-translate-instance'  => 'AATXT_ENDPOINT_AZURE_TRANSLATE_INSTANCE',
+        'aatxt_region_azure_translate_instance'    => 'AATXT_REGION_AZURE_TRANSLATE_INSTANCE',
+        'aatxt_language_azure_translate_instance'  => 'AATXT_LANGUAGE_AZURE_TRANSLATE_INSTANCE',
+        'aatxt_preserve_existing_alt_text'         => 'AATXT_PRESERVE_EXISTING_ALT_TEXT',
+    ];
+
+    /**
+     * Check whether a PHP constant is defined for the given option key.
+     *
+     * @param string $optionKey WordPress option name
+     * @return bool
+     */
+    public static function has(string $optionKey): bool
+    {
+        $constantName = self::OPTION_CONSTANT_MAP[$optionKey] ?? null;
+
+        return $constantName !== null && defined($constantName);
+    }
+
+    /**
+     * Get the value from the PHP constant for the given option key.
+     * Returns null if no constant is defined for this key.
+     *
+     * @param string $optionKey WordPress option name
+     * @return string|null
+     */
+    public static function get(string $optionKey): ?string
+    {
+        $constantName = self::OPTION_CONSTANT_MAP[$optionKey] ?? null;
+
+        if ($constantName === null || ! defined($constantName)) {
+            return null;
+        }
+
+        return (string) constant($constantName);
+    }
+
+    /**
+     * Get the PHP constant name mapped to the given option key.
+     * Returns null if no constant is mapped.
+     *
+     * @param string $optionKey WordPress option name
+     * @return string|null
+     */
+    public static function getConstantName(string $optionKey): ?string
+    {
+        return self::OPTION_CONSTANT_MAP[$optionKey] ?? null;
+    }
+}

--- a/src/App/Infrastructure/Repositories/WordPressConfigRepository.php
+++ b/src/App/Infrastructure/Repositories/WordPressConfigRepository.php
@@ -2,6 +2,8 @@
 
 namespace AATXT\App\Infrastructure\Repositories;
 
+use AATXT\App\Infrastructure\Repositories\ConstantsResolver;
+
 /**
  * WordPress Config Repository
  *
@@ -22,6 +24,10 @@ final class WordPressConfigRepository implements ConfigRepositoryInterface
      */
     public function get(string $key, $default = null)
     {
+        if (ConstantsResolver::has($key)) {
+            return ConstantsResolver::get($key);
+        }
+
         $value = get_option($key, $default);
 
         // WordPress returns false when option doesn't exist


### PR DESCRIPTION
## Summary                                                                                                                                                        
                                                                                                                                                                    
  - Adds a `ConstantsResolver` class that maps all plugin option keys to PHP constants (`AATXT_API_KEY_OPENAI`, `AATXT_TYPOLOGY`, etc.), allowing any option to be defined in `wp-config.php` instead of the database                                                                                                                
  - Constants take precedence over database values across all code paths (`PluginOptions` accessors and `WordPressConfigRepository`)                                
  - API key accessors skip decryption when a constant is active, since the value is plain text                                                                      
  - Admin settings fields are disabled with a lock icon notice when controlled by a constant                                                                        
  - Hides the encryption constants notice when no API key is stored in the database (nothing to protect yet)                                                        
  - Updates `README.md` and `readme.txt` with full documentation of supported constants                                                                             
                                                                                                                                                                    
  ## Supported constants                                                                                                                                            
                                                                                                                                                                    
```
AATXT_TYPOLOGY
AATXT_API_KEY_OPENAI
AATXT_MODEL_OPENAI
AATXT_PROMPT_OPENAI
AATXT_API_KEY_ANTHROPIC
AATXT_MODEL_ANTHROPIC
AATXT_PROMPT_ANTHROPIC
AATXT_API_KEY_AZURE_COMPUTER_VISION
AATXT_ENDPOINT_AZURE_COMPUTER_VISION
AATXT_API_KEY_AZURE_TRANSLATE_INSTANCE
AATXT_ENDPOINT_AZURE_TRANSLATE_INSTANCE
AATXT_REGION_AZURE_TRANSLATE_INSTANCE
AATXT_LANGUAGE_AZURE_TRANSLATE_INSTANCE
AATXT_PRESERVE_EXISTING_ALT_TEXT
```
                                                                                                                                                                    
  ## Test plan                                                                                                                                                    
              
  - [ ] Define `AATXT_TYPOLOGY` and `AATXT_API_KEY_OPENAI` in `wp-config.php` and confirm alt text generates correctly
  - [ ] Confirm the corresponding admin fields are disabled with the lock notice                                                                                    
  - [ ] Remove the constants and confirm the admin fields re-enable and fall back to DB values
  - [ ] Confirm API keys set via constant are not exposed in the HTML source of the settings page                                                                   
  - [ ] Confirm the encryption constants notice only appears when an API key is stored in the DB